### PR TITLE
fix: Derivar tag de imagen por version y no por antiguedad

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -92,7 +92,12 @@ jobs:
           set -euo pipefail
           NAME=$(yq -r '.app.name // "service"' "${CONFIG_FILE}" || echo service)
           CFG_VER=$(yq -r '.app.version // ""' "${CONFIG_FILE}" || true)
-          GIT_VER=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Si hay tags apuntando al commit actual, coger el mayor por version (no por antiguedad).
+          # Si no, retroceder al ultimo tag alcanzable, tambien ordenado por version.
+          GIT_VER=$(git tag --points-at HEAD --list 'v*' | sort -V | tail -n1)
+          if [ -z "$GIT_VER" ]; then
+            GIT_VER=$(git tag --merged HEAD --list 'v*' | sort -V | tail -n1)
+          fi
           RAW_VER=""
           if [ -n "$GIT_VER" ]; then RAW_VER="$GIT_VER";
           elif [ -n "$CFG_VER" ]; then RAW_VER="$CFG_VER";


### PR DESCRIPTION
## Problema

El step *Derive app name and version* de `build-push.yml` usa `git describe --tags --abbrev=0` para obtener la version que se convierte en el tag de la imagen.

Cuando **varios tags apuntan al mismo commit** (caso habitual al lanzar el workflow manual varias veces sobre el mismo commit sin pushes en medio), `git describe` devuelve el tag por **orden de creacion (antiguedad)**, no por version. Resultado: elige el tag mas antiguo (p.ej. `v2.31`) aunque exista `v2.33` en el mismo commit, y la imagen sale etiquetada con una version inferior a la real.

## Ejemplo real (repo alertor)

Los tres tags apuntan al mismo commit `f720892`:

```
f7208924...  refs/tags/v2.31
f7208924...  refs/tags/v2.32
f7208924...  refs/tags/v2.33
```

- `git describe --tags --abbrev=0` -> `v2.31`  ❌ (imagen `:2.31`)
- Con el fix -> `v2.33`  ✅ (imagen `:2.33`)

## Cambio

Reemplaza `git describe` por:

```bash
GIT_VER=$(git tag --points-at HEAD --list 'v*' | sort -V | tail -n1)
if [ -z "$GIT_VER" ]; then
  GIT_VER=$(git tag --merged HEAD --list 'v*' | sort -V | tail -n1)
fi
```

- `--points-at HEAD` + `sort -V`: si hay tags en el commit actual, coge el **mayor por version**.
- Fallback `--merged HEAD`: si el commit no tiene tag propio, retrocede al ultimo tag **alcanzable** (ancestro), tambien ordenado por version.

El checkout ya usa `fetch-depth: 0`, asi que el historial y los tags estan disponibles. Afecta a todos los repos que consumen este workflow reutilizable.